### PR TITLE
Bug fix: Editor failed renaming .tmp file to final filename with qualifiers with WSL2 on an exFAT external drive.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.50])
 AC_INIT([solo3], [2.0.0], [http://www.ral.ucar.edu/projects/titan/docs])
 
+# Keep libtool macros in an m4 directory.
 AC_CONFIG_MACRO_DIR([m4])
 
 # Explicit archiver needed for later automake
@@ -17,8 +18,6 @@ echo -n AC_PACKAGE_VERSION>VERSION
 AC_SUBST(PACKAGE_VERSION)
 AC_MSG_NOTICE([netCDF AC_PACKAGE_VERSION])
 
-# Keep libtool macros in an m4 directory.
-AC_CONFIG_MACRO_DIR([m4])
 
 # Find out about the host we're building on.
 AC_CANONICAL_HOST

--- a/editor/DataInfo.cc
+++ b/editor/DataInfo.cc
@@ -2,6 +2,7 @@
 #include <dirent.h>
 #include <sys/types.h>
 
+#include <sp_basics.hh>
 #include <DataManager.hh>
 #include <ddb_common.hh>
 #include <dd_math.h>
@@ -1614,7 +1615,24 @@ void DataInfo::updateSweepFile(const bool editing)
     if (path[path.size()-1] != '/')
       path += "/";
     path += _info->orig_sweep_file_name;
-    
+
+    //Make sure we close the files we are about to delete
+    //This is the easy one, it's in the _info variable
+    dd_close(_info->in_swp_fid);
+
+    //The harder one to find is the one open in the window
+    //Had to include sp_basics.hh to get this one
+    WW_PTR wwptr = solo_return_wwptr(0);
+    int cur_file_fd = wwptr->file_id;
+    std::string open_file_path = wwptr->sweep->directory_name;
+    if (open_file_path[open_file_path.size()-1] != '/')
+      open_file_path += "/";
+    open_file_path += wwptr->sweep->file_name;
+    //If the currently open file is the one we're about to
+    //delete, close it
+    if (open_file_path == path)
+      dd_close(cur_file_fd);
+	  
     dd_unlink(path.c_str());
   }
 


### PR DESCRIPTION
### Two issues were fixed:

1) autoreconf error:
Autoreconf was complaining about duplicate declarations "AC_CONFIG_MACRO_DIR([m4])". I just removed the second one.

2) Editor issue on exFAT file system when running from WSL2:
When using unistd.h's unlink() or stdio.h's remove() on an exFAT filesystem, at least on my machine, it seems to be necessary to close all file descriptors pointing to the file before closing. A subsequent rename attempt to the file that was supposed to be deleted (e.g swp.xyz.tmp to swp.xyz.5.0_v0) ends up failing and returning -1.  I have done so in this pull request. I'm fairly sure that the first file descriptor I closed was done properly, not as sure about the second one. I'm a little skeptical about the solo_return_wwptr(0) call. Specifically, the 0 that I passed in as a constant is scaring me a little, and I don't know the situations in which it may not be 0. This is intended to close the sweep file currently being displayed in the main window before plotting. If there is a better way to do this, please let me know and I will make appropriate changes.