### PR TITLE
Update configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@ dnl Process this file with autoconf to produce a configure script.
 AC_PREREQ([2.50])
 AC_INIT([solo3], [2.0.0], [http://www.ral.ucar.edu/projects/titan/docs])
 
-AC_CONFIG_MACRO_DIR([m4])
+
 
 # Explicit archiver needed for later automake
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])


### PR DESCRIPTION
Removed first AC_CONFIG_MACRO_DIR([m4]) command, as it is only supposed to be used once and when used a second time autoreconf exits with an error.